### PR TITLE
Add Contains To Bot List

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Minimum Python requirement: Python 3.7
 
 Full support/developed on Ubuntu-flavor Linux.
 
-Works on Windows with Python 3.8+ (support for SQLite3's JSON field type is required)
+Works on Windows with Python 3.9
 
 
 ### Overview


### PR DESCRIPTION
# Description
This PR introduces a modification to the logic in `ssi-bot\reddit_io\logic_mixin.py` to evaluate `any` author name that `contains`  `['ssi', 'bot', 'gpt2', 'gpt']`. This modification will prevent bots wrongly assigning probability to a bot with a naming scheme outside of what is implicitliy recommended. 